### PR TITLE
Handle content larger than 460 limit

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -5,15 +5,7 @@
 #include <cstdlib>
 #include <string.h>
 #include <vector>
-#include <algorithm>
-#include <filesystem>
-#include <regex>
 #include <iostream>
-#include <sstream>
-#include <fstream>
-#include <iomanip>
-#include <sys/stat.h>
-#include <sys/types.h>
 
 int main(int argc, char** argv)
 {

--- a/src/auth.h
+++ b/src/auth.h
@@ -11,7 +11,7 @@
 #define AUTH_KEY_TYPE_PRIVATE 2
 
 // DO NOT EDIT THIS VALUE
-#define AUTH_MAX_CHUNK_SIZE 470
+#define AUTH_MAX_CHUNK_SIZE 460
 
 namespace auth
 {
@@ -19,7 +19,7 @@ namespace auth
     extern const std::string AUTH_DIR_PUBLICKEYS;
     extern const std::string AUTH_DIR_PRIVATEKEYS;
 
-    struct User{
+    struct User {
         bool isAdmin;
         std::string keyName;
         std::string username;
@@ -28,7 +28,7 @@ namespace auth
         RSA *privateKey;
         void set_user(std::string username, std::string keyName = "");
         int encryptSave(char *contents, std::string path);
-        char *decrypt(char *encryptedContents);
+        char *decrypt(char *encryptedContents, int fSize = 0);
         RSA *private_key_by_name();
         RSA *get_key(int type);
     };


### PR DESCRIPTION
This new feature increase the limit to `46000` bytes by splitting content into chunks before encrypting.

Meanwhile, I reduced the chunk limit from `470` to `460` for the content size to avoid weird behavior (probably related but didn't figure out the memory leak that was handled by `flen + 1` workaround in `RSA_public_encrypt`).

Maybe padding can be reduced in the future to improve disk space usage.